### PR TITLE
Feature/systemd improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2025-03-27
+
+### Added
+
+- UseDNS no to sshd
+- AB current_version injection into a backup in the upgrade script
+- `maximum_number_of_open_file_descriptors` in common tasks
+- Discard unused blocks once a week
+- Display service_facts in smoke tests
+- new default variable
+- New limited firewalld zone for SSHD access
+
+### Changed
+
+- systemd definition of rTorrent service inside tmux
+- Standardized ruT config definitions to maintain a consistent...
+- Bumped ab & sc versions, added maximum_number_of_open_file_d...
+- Updated rtorrent.rc with maximum_number_of_open_file_descrip...
+- Minor improvement with ruT plugins
+- journald rotation improvement
+- `fail2ban_ignore_ipv4` to include private ranges
+
+### Removed
+
+- logrotate completely
+
+### Deprecated
+
+- N/A
+
+### Fixed
+
+- Incorrect role name in a few places
+- yamllint & ansible-lint passing
+
+### Security
+
+- `fail2ban_ignore_ipv4` IS NOW ALSO USED BY FIREWALLD!!!!!!!!!!
+
+
 ## [2.1.0] - 2025-03-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Role Variables
 * `rutorrent_dl` - URL of the [ruTorrent](https://github.com/Novik/ruTorrent) sources.
 * `https_port` - what port should rutorrent listen on, by default 443.
 * `htpasswd` - HTTP basic password to log in to ruTorrent interface. Default is r3dh4t.
-* `fail2ban_ignore_ipv4` - what IPv4 address should be excluded from being banned by Fail2Ban. Whitelisted is arbitrary address 123.124.125.126. You need to [change it](https://github.com/luckylittle/zero_footprint_rutorrent_seedbox/blob/master/defaults/main.yml#L42) to your own!
+* `fail2ban_ignore_ipv4` - what IPv4 address should be excluded from being banned by Fail2Ban. Whitelisted is arbitrary address 123.124.125.126. You need to [change it](https://github.com/luckylittle/zero_footprint_rutorrent_seedbox/blob/master/defaults/main.yml#L43) to your own!
 * `require_reboot` - does the machine require reboot after the playbook is finished. It is recommended & default to be true.
 
 _Note:_ Lot of the tasks rely on `remote_user` / `ansible_user` variable (user who logs in to the remote machine via Ansible). For example, it creates directory structure under that user. The ratio defaults should be sufficient (between [400%](https://github.com/luckylittle/zero_footprint_rutorrent_seedbox/blob/master/templates/rtorrent/rtorrent.rc.j2#L106)-[500%](https://github.com/luckylittle/zero_footprint_rutorrent_seedbox/blob/master/templates/rtorrent/rtorrent.rc.j2#L105)).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Role Variables
 * `set_google_dns` - if `true`, it will add Google DNS servers to the primary interface. Defaults to false.
 * `create_new_user` - whether you want to also create another user. Defaults to false.
 * `autobrr_version` & `sizechecker_version` - contains the latest [Autobrr](https://github.com/autobrr/autobrr) and [Sizechecker](https://github.com/s0up4200/sizechecker) versions.
+* `maximum_number_of_open_file_descriptors` - applicable in global, systemd, rtorrent - self explanatory, defaults to 1023.
 * `epel_dl` - URL of the [EPEL](https://docs.fedoraproject.org/en-US/epel/) RPM. Defaults to the RHEL9 EPEL.
 * `libtorrent_dl` - URL of the [libtorrent](https://github.com/rakshasa/rtorrent/releases) sources.
 * `rtorrent_dl` - URL of the [rtorrent](https://github.com/rakshasa/rtorrent/releases) sources.
@@ -59,7 +60,7 @@ Example Playbook
 - hosts: seedbox
   remote_user: redhat
   roles:
-    - luckylittle.zero_footprint_rutorrent_seedbox
+    - "luckylittle.zero_footprint_rutorrent_seedbox"
 ```
 
 Testing
@@ -300,11 +301,11 @@ MIT
 Ansible Galaxy
 --------------
 
-[luckylittle.ansible_role_zero_footprint_rut_seedbox](https://galaxy.ansible.com/ui/standalone/roles/luckylittle/zero_footprint_rutorrent_seedbox/)
+[luckylittle.zero_footprint_rutorrent_seedbox](https://galaxy.ansible.com/ui/standalone/roles/luckylittle/zero_footprint_rutorrent_seedbox/)
 
 Author Information
 ------------------
 
 Lucian Maly <<lmaly@redhat.com>>
 
-_Last update: Wed 05 Mar 2025 06:19:58 UTC_
+_Last update: Thu 27 Mar 2025 03:12:33 UTC_

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Requirements
 ------------
 
 * It is expected, that you have a brand new RHEL8/9 system and have Ansible access sorted out - including working `sudo` (you can use my other role [luckylittle/ansible-role-create-user](https://github.com/luckylittle/ansible-role-create-user) for passwordless SSH access and sudo).
-* :warning: **THIS ROLE REQUIRES PASSWORDLESS ACCESS TO YOUR SYSTEM USING SSH KEYPAIR AND NOT THE PASSWORD** (e.g. `ssh-copy-id`) - otherwise you will lock yourself out, because sshd config will change to `PasswordAuthentication no` :warning:
+* :warning: **THIS ROLE REQUIRES PASSWORDLESS ACCESS TO YOUR SYSTEM USING SSH KEYPAIR AND NOT THE PASSWORD** (e.g. `ssh-copy-id`) - otherwise you will **lock** yourself out, because sshd config will change to `PasswordAuthentication no`! :warning:
+* :warning: Make sure to add your home IP address (or multiple addresses you connect from) to `fail2ban_ignore_ipv4`, or you risk **locking** yourself out, as it is also enforced by firewalld! :warning:
 
 Role Variables
 --------------
@@ -30,7 +31,7 @@ Role Variables
 * `rutorrent_dl` - URL of the [ruTorrent](https://github.com/Novik/ruTorrent) sources.
 * `https_port` - what port should rutorrent listen on, by default 443.
 * `htpasswd` - HTTP basic password to log in to ruTorrent interface. Default is r3dh4t.
-* `fail2ban_ignore_ipv4` - what IPv4 address should be excluded from being banned by Fail2Ban. Whitelisted is arbitrary address 123.124.125.126. You need to [change it](https://github.com/luckylittle/zero_footprint_rutorrent_seedbox/blob/master/defaults/main.yml#L43) to your own!
+* `fail2ban_ignore_ipv4` - what IP addresses should be excluded from being banned by Fail2Ban and the same is also used in the **firewalld** limited zone for SSH (only these addresses are allowed to SSH to the seedbox). Whitelisted is arbitrary address `X.X.X.X` and the private IP ranges. You **need** to [change it](https://github.com/luckylittle/zero_footprint_rutorrent_seedbox/blob/master/defaults/main.yml#L43) to your own!
 * `require_reboot` - does the machine require reboot after the playbook is finished. It is recommended & default to be true.
 
 _Note:_ Lot of the tasks rely on `remote_user` / `ansible_user` variable (user who logs in to the remote machine via Ansible). For example, it creates directory structure under that user. The ratio defaults should be sufficient (between [400%](https://github.com/luckylittle/zero_footprint_rutorrent_seedbox/blob/master/templates/rtorrent/rtorrent.rc.j2#L106)-[500%](https://github.com/luckylittle/zero_footprint_rutorrent_seedbox/blob/master/templates/rtorrent/rtorrent.rc.j2#L105)).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,8 +6,9 @@ set_timezone: "Europe/Prague"
 set_google_dns: false
 create_new_user: false
 new_user: "redhat"
-autobrr_version: "1.59.0"
-sizechecker_version: "1.2.0"
+autobrr_version: "1.60.0"
+sizechecker_version: "1.3.0"
+maximum_number_of_open_file_descriptors: "1023"
 
 # 02-rtorrent
 epel_dl: "https://dl.fedoraproject.org/pub/epel/\

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,7 @@ htpasswd: !vault |
 # command. The value is `r3dh4t`, password to decrypt is `password1`.
 
 # 05-security
-fail2ban_ignore_ipv4: "123.124.125.126"
+fail2ban_ignore_ipv4: "127.0.0.1/8 ::1 192.168.0.1/16 10.0.0.0/8 172.16.0.0/12 123.124.125.126"
 
 # 07-reboot
 require_reboot: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,7 @@ htpasswd: !vault |
 # command. The value is `r3dh4t`, password to decrypt is `password1`.
 
 # 05-security
-fail2ban_ignore_ipv4: "127.0.0.1/8 ::1 192.168.0.1/16 10.0.0.0/8 172.16.0.0/12 123.124.125.126"
+fail2ban_ignore_ipv4: "127.0.0.1/8 ::1 192.168.0.1/16 10.0.0.0/8 172.16.0.0/12 X.X.X.X"
 
 # 07-reboot
 require_reboot: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,8 @@ htpasswd: !vault |
 # command. The value is `r3dh4t`, password to decrypt is `password1`.
 
 # 05-security
-fail2ban_ignore_ipv4: "127.0.0.1/8 ::1 192.168.0.1/16 10.0.0.0/8 172.16.0.0/12 X.X.X.X"
+fail2ban_ignore_ipv4: |
+  "127.0.0.1/8 ::1 192.168.0.1/16 10.0.0.0/8 172.16.0.0/12 X.X.X.X"
 
 # 07-reboot
 require_reboot: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ single_user: false
 
 # 04-rutorrent
 rutorrent_dl: "https://github.com/Novik/ruTorrent/archive/\
-              refs/tags/v5.1.5.tar.gz"
+              refs/tags/v5.1.6.tar.gz"
 https_port: 443
 htpasswd: !vault |
   $ANSIBLE_VAULT;1.1;AES256
@@ -40,7 +40,7 @@ htpasswd: !vault |
 # command. The value is `r3dh4t`, password to decrypt is `password1`.
 
 # 05-security
-fail2ban_ignore_ipv4: |
+fail2ban_ignore_ipv4: >-
   "127.0.0.1/8 ::1 192.168.0.1/16 10.0.0.0/8 172.16.0.0/12 X.X.X.X"
 
 # 07-reboot

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,6 +8,12 @@
 
 - name: Restart journal
   ansible.builtin.systemd_service:
-    state: restarted
+    state: "restarted"
     name: "systemd-journald"
+  become: true
+
+- name: Reload sshd
+  ansible.builtin.systemd_service:
+    state: "reloaded"
+    name: "sshd"
   become: true

--- a/tasks/01-common.yml
+++ b/tasks/01-common.yml
@@ -220,3 +220,30 @@
   become: true
   tags:
     - common
+
+- name: COMMON | 1.22 Systemd wide DefaultLimitNOFILE
+  ansible.builtin.lineinfile:
+    path: "/etc/systemd/system.conf"
+    regexp: '^#DefaultLimitNOFILE=.*'
+    line: "DefaultLimitNOFILE={{ maximum_number_of_open_file_descriptors }}"
+  become: true
+  tags:
+    - common
+
+- name: COMMON | 1.23 Set soft nofile limit
+  ansible.builtin.lineinfile:
+    path: "/etc/security/limits.conf"
+    line: "{{ ansible_user }} soft nofile {{ maximum_number_of_open_file_descriptors }}"
+    insertbefore: '^# End of file$'
+  become: true
+  tags:
+    - common
+
+- name: COMMON | 1.24 Set hard nofile limit
+  ansible.builtin.lineinfile:
+    path: "/etc/security/limits.conf"
+    line: "{{ ansible_user }} hard nofile {{ maximum_number_of_open_file_descriptors }}"
+    insertbefore: '^# End of file$'
+  become: true
+  tags:
+    - common

--- a/tasks/01-common.yml
+++ b/tasks/01-common.yml
@@ -233,7 +233,8 @@
 - name: COMMON | 1.23 Set soft nofile limit
   ansible.builtin.lineinfile:
     path: "/etc/security/limits.conf"
-    line: "{{ ansible_user }} soft nofile {{ maximum_number_of_open_file_descriptors }}"
+    line: "{{ ansible_user }} soft nofile \
+          {{ maximum_number_of_open_file_descriptors }}"
     insertbefore: '^# End of file$'
   become: true
   tags:
@@ -242,7 +243,8 @@
 - name: COMMON | 1.24 Set hard nofile limit
   ansible.builtin.lineinfile:
     path: "/etc/security/limits.conf"
-    line: "{{ ansible_user }} hard nofile {{ maximum_number_of_open_file_descriptors }}"
+    line: "{{ ansible_user }} hard nofile \
+          {{ maximum_number_of_open_file_descriptors }}"
     insertbefore: '^# End of file$'
   become: true
   tags:

--- a/tasks/04-rutorrent.yml
+++ b/tasks/04-rutorrent.yml
@@ -96,7 +96,6 @@
     path: "/var/www/ruTorrent/conf/plugins.ini"
     line: "{{ item }}"
     create: true
-    backup: true
     mode: "0664"
   become: true
   loop:
@@ -124,7 +123,29 @@
   tags:
     - rutorrent
 
-- name: RUTORRENT | 4.10 Copy the configuration for php-fpm
+- name: RUTORRENT | 4.10 Change Plugins from user-defined to yes
+  community.general.ini_file:
+    path: "/var/www/ruTorrent/conf/plugins.ini"
+    section: "default"
+    option: "enabled"
+    value: "yes"
+    mode: "0664"
+    backup: true
+  tags:
+    - rutorrent
+
+- name: RUTORRENT | 4.11 Hide the Plugins tab
+  community.general.ini_file:
+    path: "/var/www/ruTorrent/conf/access.ini"
+    section: "tabs"
+    option: "showPluginsTab"
+    value: "no"
+    mode: "0664"
+    backup: true
+  tags:
+    - rutorrent
+
+- name: RUTORRENT | 4.12 Copy the configuration for php-fpm
   ansible.builtin.copy:
     src: "lighttpd/www.conf"
     dest: "/etc/php-fpm.d/www.conf"
@@ -134,7 +155,7 @@
   tags:
     - rutorrent
 
-- name: RUTORRENT | 4.11 php-fpm log is sent to syslogd
+- name: RUTORRENT | 4.13 php-fpm log is sent to syslogd
   ansible.builtin.lineinfile:
     path: "/etc/php-fpm.conf"
     regexp: '^error_log = /var/log/php-fpm/error.log'
@@ -143,7 +164,7 @@
   tags:
     - rutorrent
 
-- name: RUTORRENT | 4.12 Template the configuration for lighttpd
+- name: RUTORRENT | 4.14 Template the configuration for lighttpd
   ansible.builtin.template:
     src: "lighttpd/lighttpd.conf.j2"
     dest: "/etc/lighttpd/lighttpd.conf"
@@ -153,7 +174,7 @@
   tags:
     - rutorrent
 
-- name: RUTORRENT | 4.13 Copy the configuration for lighttpd modules
+- name: RUTORRENT | 4.15 Copy the configuration for lighttpd modules
   ansible.builtin.copy:
     src: "lighttpd/modules.conf"
     dest: "/etc/lighttpd/modules.conf"
@@ -163,7 +184,7 @@
   tags:
     - rutorrent
 
-- name: RUTORRENT | 4.14 Copy the configuration for auth module
+- name: RUTORRENT | 4.16 Copy the configuration for auth module
   ansible.builtin.template:
     src: "lighttpd/auth.conf.j2"
     dest: "/etc/lighttpd/conf.d/auth.conf"
@@ -173,7 +194,7 @@
   tags:
     - rutorrent
 
-- name: RUTORRENT | 4.15 Copy the configuration for fastcgi module
+- name: RUTORRENT | 4.17 Copy the configuration for fastcgi module
   ansible.builtin.copy:
     src: "lighttpd/fastcgi.conf"
     dest: "/etc/lighttpd/conf.d/fastcgi.conf"
@@ -183,7 +204,7 @@
   tags:
     - rutorrent
 
-- name: RUTORRENT | 4.16 Add a user to a htpasswd file and ensure \
+- name: RUTORRENT | 4.18 Add a user to a htpasswd file and ensure \
         permissions are set
   community.general.htpasswd:
     path: "/var/www/ruTorrent/.htpasswd"
@@ -196,7 +217,7 @@
   tags:
     - rutorrent
 
-- name: RUTORRENT | 4.17 Copy the configuration for proxy module
+- name: RUTORRENT | 4.19 Copy the configuration for proxy module
   ansible.builtin.template:
     src: "lighttpd/proxy.conf.j2"
     dest: "/etc/lighttpd/conf.d/proxy.conf"
@@ -206,7 +227,7 @@
   tags:
     - rutorrent
 
-- name: RUTORRENT | 4.18 Validate the lighttpd config files
+- name: RUTORRENT | 4.20 Validate the lighttpd config files
   ansible.builtin.command: "lighttpd -t -f {{ item }}"
   args:
     chdir: "/etc/lighttpd/"

--- a/tasks/04-rutorrent.yml
+++ b/tasks/04-rutorrent.yml
@@ -131,6 +131,7 @@
     value: "yes"
     mode: "0664"
     backup: true
+  become: true
   tags:
     - rutorrent
 
@@ -142,6 +143,7 @@
     value: "no"
     mode: "0664"
     backup: true
+  become: true
   tags:
     - rutorrent
 

--- a/tasks/05-security.yml
+++ b/tasks/05-security.yml
@@ -69,7 +69,6 @@
 - name: SECURITY | 5.7 Create a new firewalld zone "limited"
   ansible.posix.firewalld:
     zone: "limited"
-    source: "{{ fail2ban_ignore_ipv4 }}"
     state: "present"
     permanent: true
   become: true
@@ -78,7 +77,20 @@
   tags:
     - security
 
-- name: SECURITY | 5.8 Permit traffic in "default" zone for https service
+- name: SECURITY | 5.8 Add source to a new firewalld zone "limited"
+  ansible.posix.firewalld:
+    zone: "limited"
+    source: "{{ item }}"
+    state: "enabled"
+    permanent: true
+  become: true
+  notify:
+    - "Reload firewalld"
+  loop: "{{ fail2ban_ignore_ipv4 | replace('\"', '') | split(' ') }}"
+  tags:
+    - security
+
+- name: SECURITY | 5.9 Permit traffic in "default" zone for https service
   ansible.posix.firewalld:
     service: "{{ item }}"
     permanent: true
@@ -91,7 +103,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.9 Permit traffic in "default" zone for various rtorrent, \
+- name: SECURITY | 5.10 Permit traffic in "default" zone for various rtorrent, \
         vsftpd, autobrr ports
   ansible.posix.firewalld:
     port: "{{ item }}"
@@ -108,7 +120,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.10 Deny traffic in "default" zone for cockpit
+- name: SECURITY | 5.11 Deny traffic in "default" zone for cockpit
   ansible.posix.firewalld:
     service: "cockpit"
     permanent: true
@@ -119,18 +131,21 @@
   tags:
     - security
 
-- name: SECURITY | 5.11 Deny ICMP traffic in "default" zone
+- name: SECURITY | 5.12 Deny ICMP traffic in "default" zone
   ansible.posix.firewalld:
-    icmp_block: echo-request,echo-reply
+    icmp_block: "{{ item }}"
     permanent: true
     state: "enabled"
   become: true
   notify:
     - "Reload firewalld"
+  loop:
+    - "echo-request"
+    - "echo-reply"
   tags:
     - security
 
-- name: SECURITY | 5.12 Permit traffic in "limited" zone for various rtorrent, \
+- name: SECURITY | 5.13 Permit traffic in "limited" zone for various rtorrent, \
         vsftpd, autobrr ports
   ansible.posix.firewalld:
     zone: "limited"
@@ -148,7 +163,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.13 Permit traffic in "limited" zone for https, sshd service
+- name: SECURITY | 5.14 Permit traffic in "limited" zone for https, sshd service
   ansible.posix.firewalld:
     zone: "limited"
     service: "{{ item }}"
@@ -163,7 +178,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.14 Template the configuration for SSHD
+- name: SECURITY | 5.15 Template the configuration for SSHD
   ansible.builtin.template:
     src: "sshd/sshd_config.j2"
     dest: "/etc/ssh/sshd_config"
@@ -175,7 +190,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.15 Copy the configuration for Fail2Ban (jail)
+- name: SECURITY | 5.16 Copy the configuration for Fail2Ban (jail)
   ansible.builtin.copy:
     src: "fail2ban/jail.local"
     dest: "/etc/fail2ban/jail.local"
@@ -185,7 +200,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.16 Copy the configuration for Fail2Ban (lighttpd)
+- name: SECURITY | 5.17 Copy the configuration for Fail2Ban (lighttpd)
   ansible.builtin.copy:
     src: "fail2ban/lighttpd-auth.local"
     dest: "/etc/fail2ban/jail.d/lighttpd-auth.local"
@@ -195,7 +210,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.17 Copy the configuration for Fail2Ban (sshd)
+- name: SECURITY | 5.18 Copy the configuration for Fail2Ban (sshd)
   ansible.builtin.copy:
     src: "fail2ban/sshd.local"
     dest: "/etc/fail2ban/jail.d/sshd.local"
@@ -205,7 +220,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.18 Template the configuration for Fail2Ban (vsftpd)
+- name: SECURITY | 5.19 Template the configuration for Fail2Ban (vsftpd)
   ansible.builtin.template:
     src: "fail2ban/vsftpd.local.j2"
     dest: "/etc/fail2ban/jail.d/vsftpd.local"
@@ -215,7 +230,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.19 Make exceptions for some IP addresses for Fail2Ban
+- name: SECURITY | 5.20 Make exceptions for some IP addresses for Fail2Ban
   ansible.builtin.lineinfile:
     path: "/etc/fail2ban/jail.conf"
     regexp: '^#ignoreip = 127.0.0.1/8 ::1$'
@@ -225,7 +240,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.20 Change logging of Fail2Ban to systemd
+- name: SECURITY | 5.21 Change logging of Fail2Ban to systemd
   ansible.builtin.lineinfile:
     path: "/etc/fail2ban/fail2ban.conf"
     regexp: '^logtarget =.*'
@@ -234,7 +249,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.21 Copy the filter for Fail2Ban (lighttpd-auth)
+- name: SECURITY | 5.22 Copy the filter for Fail2Ban (lighttpd-auth)
   ansible.builtin.copy:
     src: "fail2ban/lighttpd-auth.conf"
     dest: "/etc/fail2ban/filter.d/lighttpd-auth.conf"
@@ -244,7 +259,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.22 Copy the filter for Fail2Ban (vsftpd)
+- name: SECURITY | 5.23 Copy the filter for Fail2Ban (vsftpd)
   ansible.builtin.copy:
     src: "fail2ban/vsftpd.conf"
     dest: "/etc/fail2ban/filter.d/vsftpd.conf"
@@ -254,7 +269,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.23 Disable shell history
+- name: SECURITY | 5.24 Disable shell history
   ansible.builtin.lineinfile:
     path: "/etc/profile"
     regexp: '^HISTSIZE=1000$'

--- a/tasks/05-security.yml
+++ b/tasks/05-security.yml
@@ -120,14 +120,17 @@
   tags:
     - security
 
-- name: SECURITY | 5.11 Deny traffic in "default" zone for cockpit
+- name: SECURITY | 5.11 Deny traffic in "default" zone for cockpit and ssh
   ansible.posix.firewalld:
-    service: "cockpit"
+    service: "{{ item }}"
     permanent: true
     state: "disabled"
   become: true
   notify:
     - "Reload firewalld"
+  loop:
+    - "cockpit"
+    - "ssh"
   tags:
     - security
 

--- a/tasks/05-security.yml
+++ b/tasks/05-security.yml
@@ -66,27 +66,40 @@
   tags:
     - security
 
-- name: SECURITY | 5.7 Permit traffic in default zone for https, ssh services
+- name: SECURITY | 5.7 Create a new firewalld zone "limited"
+  ansible.posix.firewalld:
+    zone: "limited"
+    source: "{{ fail2ban_ignore_ipv4 }}"
+    state: "present"
+    permanent: true
+  become: true
+  notify:
+    - "Reload firewalld"
+  tags:
+    - security
+
+- name: SECURITY | 5.8 Permit traffic in "default" zone for https service
   ansible.posix.firewalld:
     service: "{{ item }}"
     permanent: true
-    immediate: true
     state: "enabled"
   become: true
+  notify:
+    - "Reload firewalld"
   loop:
-    - ssh
     - https
   tags:
     - security
 
-- name: SECURITY | 5.8 Permit traffic in default zone for various rtorrent, \
+- name: SECURITY | 5.9 Permit traffic in "default" zone for various rtorrent, \
         vsftpd, autobrr ports
   ansible.posix.firewalld:
     port: "{{ item }}"
     permanent: true
-    immediate: true
     state: "enabled"
   become: true
+  notify:
+    - "Reload firewalld"
   loop:
     - "{{ rtorrent_port }}/tcp"
     - "{{ rtorrent_port }}/udp"
@@ -95,11 +108,10 @@
   tags:
     - security
 
-- name: SECURITY | 5.9 Deny traffic in default zone for cockpit
+- name: SECURITY | 5.10 Deny traffic in "default" zone for cockpit
   ansible.posix.firewalld:
     service: "cockpit"
     permanent: true
-    immediate: true
     state: "disabled"
   become: true
   notify:
@@ -107,17 +119,63 @@
   tags:
     - security
 
-- name: SECURITY | 5.10 Template the configuration for SSHD
+- name: SECURITY | 5.11 Deny ICMP traffic in "default" zone
+  ansible.posix.firewalld:
+    icmp_block: echo-request,echo-reply
+    permanent: true
+    state: "enabled"
+  become: true
+  notify:
+    - "Reload firewalld"
+  tags:
+    - security
+
+- name: SECURITY | 5.12 Permit traffic in "limited" zone for various rtorrent, \
+        vsftpd, autobrr ports
+  ansible.posix.firewalld:
+    zone: "limited"
+    port: "{{ item }}"
+    permanent: true
+    state: "enabled"
+  become: true
+  notify:
+    - "Reload firewalld"
+  loop:
+    - "{{ rtorrent_port }}/tcp"
+    - "{{ rtorrent_port }}/udp"
+    - "{{ ftp_port }}/tcp"
+    - "{{ pasv_port_range }}/tcp"
+  tags:
+    - security
+
+- name: SECURITY | 5.13 Permit traffic in "limited" zone for https, sshd service
+  ansible.posix.firewalld:
+    zone: "limited"
+    service: "{{ item }}"
+    permanent: true
+    state: "enabled"
+  become: true
+  notify:
+    - "Reload firewalld"
+  loop:
+    - https
+    - ssh
+  tags:
+    - security
+
+- name: SECURITY | 5.14 Template the configuration for SSHD
   ansible.builtin.template:
     src: "sshd/sshd_config.j2"
     dest: "/etc/ssh/sshd_config"
     backup: true
     mode: "0600"
   become: true
+  notify:
+    - "Reload sshd"
   tags:
     - security
 
-- name: SECURITY | 5.11 Copy the configuration for Fail2Ban (jail)
+- name: SECURITY | 5.15 Copy the configuration for Fail2Ban (jail)
   ansible.builtin.copy:
     src: "fail2ban/jail.local"
     dest: "/etc/fail2ban/jail.local"
@@ -127,7 +185,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.12 Copy the configuration for Fail2Ban (lighttpd)
+- name: SECURITY | 5.16 Copy the configuration for Fail2Ban (lighttpd)
   ansible.builtin.copy:
     src: "fail2ban/lighttpd-auth.local"
     dest: "/etc/fail2ban/jail.d/lighttpd-auth.local"
@@ -137,7 +195,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.13 Copy the configuration for Fail2Ban (sshd)
+- name: SECURITY | 5.17 Copy the configuration for Fail2Ban (sshd)
   ansible.builtin.copy:
     src: "fail2ban/sshd.local"
     dest: "/etc/fail2ban/jail.d/sshd.local"
@@ -147,7 +205,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.14 Template the configuration for Fail2Ban (vsftpd)
+- name: SECURITY | 5.18 Template the configuration for Fail2Ban (vsftpd)
   ansible.builtin.template:
     src: "fail2ban/vsftpd.local.j2"
     dest: "/etc/fail2ban/jail.d/vsftpd.local"
@@ -157,18 +215,17 @@
   tags:
     - security
 
-- name: SECURITY | 5.15 Make exceptions for some IP addresses for Fail2Ban
+- name: SECURITY | 5.19 Make exceptions for some IP addresses for Fail2Ban
   ansible.builtin.lineinfile:
     path: "/etc/fail2ban/jail.conf"
     regexp: '^#ignoreip = 127.0.0.1/8 ::1$'
-    line: "ignoreip = 127.0.0.1/8 ::1 192.168.0.1/16 10.0.0.0/8 \
-          172.16.0.0/12 {{ fail2ban_ignore_ipv4 }}"
+    line: "ignoreip = {{ fail2ban_ignore_ipv4 }}"
     backup: true
   become: true
   tags:
     - security
 
-- name: SECURITY | 5.16 Change logging of Fail2Ban to systemd
+- name: SECURITY | 5.20 Change logging of Fail2Ban to systemd
   ansible.builtin.lineinfile:
     path: "/etc/fail2ban/fail2ban.conf"
     regexp: '^logtarget =.*'
@@ -177,7 +234,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.17 Copy the filter for Fail2Ban (lighttpd-auth)
+- name: SECURITY | 5.21 Copy the filter for Fail2Ban (lighttpd-auth)
   ansible.builtin.copy:
     src: "fail2ban/lighttpd-auth.conf"
     dest: "/etc/fail2ban/filter.d/lighttpd-auth.conf"
@@ -187,7 +244,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.18 Copy the filter for Fail2Ban (vsftpd)
+- name: SECURITY | 5.22 Copy the filter for Fail2Ban (vsftpd)
   ansible.builtin.copy:
     src: "fail2ban/vsftpd.conf"
     dest: "/etc/fail2ban/filter.d/vsftpd.conf"
@@ -197,7 +254,7 @@
   tags:
     - security
 
-- name: SECURITY | 5.19 Disable shell history
+- name: SECURITY | 5.23 Disable shell history
   ansible.builtin.lineinfile:
     path: "/etc/profile"
     regexp: '^HISTSIZE=1000$'

--- a/tasks/06-cleanup.yml
+++ b/tasks/06-cleanup.yml
@@ -91,7 +91,40 @@
   tags:
     - cleanup
 
-- name: CLEANUP | 6.8 Ensure rhsm logging is disabled
+- name: CLEANUP | 6.8 Lower jourland RuntimeMaxUse
+  ansible.builtin.lineinfile:
+    path: "/etc/systemd/journald.conf"
+    regexp: '^#RuntimeMaxUse=.*'
+    line: "RuntimeMaxUse=32M"
+  notify:
+    - "Restart journal"
+  become: true
+  tags:
+    - cleanup
+
+- name: CLEANUP | 6.9 Lower jourland RuntimeMaxFileSize
+  ansible.builtin.lineinfile:
+    path: "/etc/systemd/journald.conf"
+    regexp: '^#RuntimeMaxFileSize=.*'
+    line: "RuntimeMaxFileSize=32M"
+  notify:
+    - "Restart journal"
+  become: true
+  tags:
+    - cleanup
+
+- name: CLEANUP | 6.10 Lower jourland RuntimeMaxFiles
+  ansible.builtin.lineinfile:
+    path: "/etc/systemd/journald.conf"
+    regexp: '^#RuntimeMaxFiles=100.*'
+    line: "RuntimeMaxFiles=1"
+  notify:
+    - "Restart journal"
+  become: true
+  tags:
+    - cleanup
+
+- name: CLEANUP | 6.11 Ensure rhsm logging is disabled
   community.general.ini_file:
     path: "/etc/rhsm/rhsm.conf"
     section: "rhsmcertd"
@@ -103,7 +136,7 @@
   tags:
     - cleanup
 
-- name: CLEANUP | 6.9 Ensure rhsm logging is only ERROR
+- name: CLEANUP | 6.12 Ensure rhsm logging is only ERROR
   community.general.ini_file:
     path: "/etc/rhsm/rhsm.conf"
     section: "logging"
@@ -114,7 +147,7 @@
   tags:
     - cleanup
 
-- name: CLEANUP | 6.10 Disable DNF logging
+- name: CLEANUP | 6.13 Disable DNF logging
   ansible.builtin.lineinfile:
     path: "/etc/dnf/dnf.conf"
     line: "logfilelevel=0"
@@ -125,176 +158,7 @@
   tags:
     - cleanup
 
-- name: CLEANUP | 6.11 Minimise general logrotate to daily
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.conf"
-    regexp: '^weekly$'
-    line: "daily"
-    backup: true
-  become: true
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.12 Minimise general logrotate to 1
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.conf"
-    regexp: '^rotate 4$'
-    line: "rotate 1"
-  become: true
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.13 Check if bootlog logrotate config exists
-  ansible.builtin.stat:
-    path: "/etc/logrotate.d/bootlog"
-  register: bootlog_file
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.14 Minimise bootlog logrotate to 1
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/bootlog"
-    regexp: '^    rotate 7$'
-    line: "    rotate 1"
-  become: true
-  when: bootlog_file.stat.exists
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.15 Minimise btmp logrotate to daily
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/btmp"
-    regexp: '^    monthly$'
-    line: "    daily"
-  become: true
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.16 Minimise dnf logrotate to daily
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/dnf"
-    regexp: '^    weekly$'
-    line: "    daily"
-  become: true
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.17 Minimise dnf logrotate to 1
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/dnf"
-    regexp: '^    rotate 4$'
-    line: "    rotate 1"
-  become: true
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.18 Minimise firewalld logrotate to daily
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/firewalld"
-    regexp: '^    weekly$'
-    line: "    daily"
-  become: true
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.19 Minimise firewalld logrotate to 1
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/firewalld"
-    regexp: '^    rotate 4$'
-    line: "    rotate 1"
-  become: true
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.20 Check if iscsiuiolog logrotate config exists
-  ansible.builtin.stat:
-    path: "/etc/logrotate.d/iscsiuiolog"
-  register: iscsiuiolog_file
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.21 Minimise iscsiuiolog logrotate to daily
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/iscsiuiolog"
-    regexp: '^    weekly$'
-    line: "    daily"
-  become: true
-  when: iscsiuiolog_file.stat.exists
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.22 Minimise iscsiuiolog logrotate to 1
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/iscsiuiolog"
-    regexp: '^    rotate 4$'
-    line: "    rotate 1"
-  become: true
-  when: iscsiuiolog_file.stat.exists
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.23 Check if psacct logrotate config exists
-  ansible.builtin.stat:
-    path: "/etc/logrotate.d/psacct"
-  register: psacct_file
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.24 Minimise psacct logrotate to 1
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/psacct"
-    regexp: '^    rotate 31$'
-    line: "    rotate 1"
-  become: true
-  when: psacct_file.stat.exists
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.25 Check if psacct logrotate config exists
-  ansible.builtin.stat:
-    path: "/etc/logrotate.d/samba"
-  register: samba_file
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.26 Minimise samba logrotate to 1
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/samba"
-    regexp: '^    rotate 99$'
-    line: "    rotate 1"
-  become: true
-  when: samba_file.stat.exists
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.27 Minimise sssd logrotate to daily
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/sssd"
-    regexp: '^    weekly$'
-    line: "    daily"
-  become: true
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.28 Minimise sssd logrotate to 1
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/sssd"
-    regexp: '^    rotate 2$'
-    line: "    rotate 1"
-  become: true
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.29 Minimise wtmp logrotate to daily
-  ansible.builtin.lineinfile:
-    path: "/etc/logrotate.d/wtmp"
-    regexp: '^    monthly$'
-    line: "    daily"
-  become: true
-  tags:
-    - cleanup
-
-- name: CLEANUP | 6.30 Find all logs in /var/log
+- name: CLEANUP | 6.14 Find all logs in /var/log
   ansible.builtin.find:
     paths: "/var/log"
     recurse: true
@@ -304,7 +168,7 @@
   tags:
     - cleanup
 
-- name: CLEANUP | 6.31 Remove all var_log_files
+- name: CLEANUP | 6.15 Remove all var_log_files
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: "absent"
@@ -313,7 +177,7 @@
   tags:
     - cleanup
 
-- name: CLEANUP | 6.32 Create a symbolic link pointing to \
+- name: CLEANUP | 6.16 Create a symbolic link pointing to \
         /dev/null for all remaining logs
   ansible.builtin.file:
     src: "/dev/null"
@@ -330,16 +194,33 @@
     - "/var/log/lastlog"
     - "/var/log/rhsm/rhsm.log"
     - "/var/log/rhsm/rhsmcertd.log"
+    - "/var/log/sssd/sssd_kcm.log"
     - "/var/log/tallylog"
     - "/var/log/tuned/tuned.log"
     - "/var/log/wtmp"
   tags:
     - cleanup
 
-- name: CLEANUP | 6.33 Remove all remaining packages that are not being used
+- name: CLEANUP | 6.17 Remove all remaining packages that are not being used
   ansible.builtin.command: "dnf autoremove -y"
   register: dnf_autoremove
   changed_when: "'Complete!' in dnf_autoremove.stdout"
+  become: true
+  tags:
+    - cleanup
+
+- name: CLEANUP | 6.18 Remove logrotate without dependency (vsftpd)
+  ansible.builtin.command: "sudo rpm -e --nodeps logrotate"  # Removing
+  # logrotate via dnf would remove vsftpd
+  removes: "/etc/logrotate.conf"
+  become: true
+  tags:
+    - cleanup
+
+- name: CLEANUP | 6.19 Remove /etc/logrotate.d/
+  ansible.builtin.file:
+    path: "/etc/logrotate.d/"
+    state: "absent"
   become: true
   tags:
     - cleanup

--- a/tasks/06-cleanup.yml
+++ b/tasks/06-cleanup.yml
@@ -212,7 +212,8 @@
 - name: CLEANUP | 6.18 Remove logrotate without dependency (vsftpd)
   ansible.builtin.command: "sudo rpm -e --nodeps logrotate"  # Removing
   # logrotate via dnf would remove vsftpd
-  removes: "/etc/logrotate.conf"
+  args:
+    removes: "/etc/logrotate.conf"
   become: true
   tags:
     - cleanup

--- a/tasks/07-reboot.yml
+++ b/tasks/07-reboot.yml
@@ -17,6 +17,7 @@
   loop:
     - "{{ autobrr_service }}"
     - "fail2ban"
+    - "fstrim.timer"
     - "lighttpd"
     - "php-fpm"
     - "rtorrent"

--- a/tasks/08-smoke_tests.yml
+++ b/tasks/08-smoke_tests.yml
@@ -120,3 +120,27 @@
       - "AUTOBRR:           {{ test_autobrr.msg }}"
   tags:
     - smoke_tests
+
+- name: TEST | 8.14 Output
+  ansible.builtin.debug:
+    msg:
+      - "----------------------------------------------------------------"
+      - "Autobrr URL:"
+      - "https://{{ ansible_user }}:{{ htpasswd }}@{{ (ansible_ssh_host | \
+          default(ansible_host)) | default(inventory_hostname) }}/autobrr/"
+      - "----------------------------------------------------------------"
+      - "ruTorrent URL:"
+      - "https://{{ ansible_user }}:{{ htpasswd }}@{{ (ansible_ssh_host | \
+          default(ansible_host)) | default(inventory_hostname) }}"
+      - "----------------------------------------------------------------"
+      - "vsFTPd URL:"
+      - "ftps://{{ (ansible_ssh_host | default(ansible_host)) | \
+          default(inventory_hostname) }}:{{ ftp_port }}"
+      - "----------------------------------------------------------------"
+      - "nzb360 Torrent settings URL:"
+      - "https://{{ ansible_user }}:{{ htpasswd }}@{{ (ansible_ssh_host | \
+          default(ansible_host)) | default(inventory_hostname) }}/plugins\
+          /httprpc/action.php"
+      - "----------------------------------------------------------------"
+  tags:
+    - smoke_tests

--- a/tasks/08-smoke_tests.yml
+++ b/tasks/08-smoke_tests.yml
@@ -80,3 +80,14 @@
       - "AUTOBRR: {{ test_autobrr.status }}"
   tags:
     - smoke_tests
+
+- name: TEST | 8.8 Populate service facts
+  ansible.builtin.service_facts:
+  tags:
+    - smoke_tests
+
+- name: TEST | 8.9 Print service facts
+  ansible.builtin.debug:
+    var: ansible_facts.services
+  tags:
+    - smoke_tests

--- a/tasks/08-smoke_tests.yml
+++ b/tasks/08-smoke_tests.yml
@@ -1,39 +1,78 @@
 ---
 # tasks file for ansible-role-zero-footprint-ruT-seedbox/08-smoke_test
 
-- name: TEST | 8.1 Check for port 22 to be open and contain "OpenSSH"
+- name: TEST | 8.1 Populate service_facts
+  ansible.builtin.service_facts:
+  tags:
+    - smoke_tests
+
+- name: TEST | 8.2 Print ACTIVE services
+  ansible.builtin.debug:
+    var: ansible_facts['services'].values() |
+          selectattr('state','equalto','active') |
+          map(attribute='name') | list
+  tags:
+    - smoke_tests
+
+- name: TEST | 8.3 Print INACTIVE services
+  ansible.builtin.debug:
+    var: ansible_facts['services'].values() |
+          selectattr('state','equalto','inactive') |
+          map(attribute='name') | list
+  tags:
+    - smoke_tests
+
+- name: TEST | 8.4 Print RUNNING services
+  ansible.builtin.debug:
+    var: ansible_facts['services'].values() |
+          selectattr('state','equalto','running') |
+          map(attribute='name') | list
+  tags:
+    - smoke_tests
+
+- name: TEST | 8.5 Print STOPPED services
+  ansible.builtin.debug:
+    var: ansible_facts['services'].values() |
+          selectattr('state','equalto','stopped') |
+          map(attribute='name') | list
+  tags:
+    - smoke_tests
+
+- name: TEST | 8.6 Print UNKNOWN services
+  ansible.builtin.debug:
+    var: ansible_facts['services'].values() |
+          selectattr('state','equalto','unknown') |
+          map(attribute='name') | list
+  tags:
+    - smoke_tests
+
+- name: TEST | 8.7 Check for port 22 to be open and contain "OpenSSH"
   ansible.builtin.wait_for:
     port: 22
-    host: "{{ (ansible_ssh_host | default(ansible_host)) | default\
-          (inventory_hostname) }}"
     search_regex: "OpenSSH"
     timeout: 60
   register: test_ssh
   tags:
     - smoke_tests
 
-- name: TEST | 8.2 Check for FTP port to be open and contain "220 Welcome to"
+- name: TEST | 8.8 Check for FTP port to be open and contain "220 Welcome to"
   ansible.builtin.wait_for:
     port: "{{ ftp_port }}"
-    host: "{{ (ansible_ssh_host | default(ansible_host)) | default\
-          (inventory_hostname) }}"
     search_regex: "220 Welcome to"
     timeout: 60
   register: test_ftp
   tags:
     - smoke_tests
 
-- name: TEST | 8.3 Check for rtorrent port to be open
+- name: TEST | 8.9 Check for rtorrent port to be open
   ansible.builtin.wait_for:
     port: "{{ rtorrent_port }}"
-    host: "{{ (ansible_ssh_host | default(ansible_host)) | default\
-          (inventory_hostname) }}"
     timeout: 60
   register: test_rtorrent
   tags:
     - smoke_tests
 
-- name: TEST | 8.4 Check for RPC rtorrent endpoint to be open
+- name: TEST | 8.10 Check for RPC rtorrent endpoint to be open
   ansible.builtin.uri:
     url: "https://{{ ansible_user }}:{{ htpasswd }}@{{ (ansible_ssh_host | \
           default(ansible_host)) | default(inventory_hostname) }}/plugins/\
@@ -45,7 +84,7 @@
   tags:
     - smoke_tests
 
-- name: TEST | 8.5 Check for HTTPS rutorrent port to be open
+- name: TEST | 8.11 Check for HTTPS rutorrent port to be open
   ansible.builtin.uri:
     url: "https://{{ ansible_user }}:{{ htpasswd }}@{{ (ansible_ssh_host | \
           default(ansible_host)) | default(inventory_hostname) }}:{{ \
@@ -57,7 +96,7 @@
   tags:
     - smoke_tests
 
-- name: TEST | 8.6 Check for Autobrr to be responding
+- name: TEST | 8.12 Check for Autobrr to be responding
   ansible.builtin.uri:
     url: "https://{{ ansible_user }}:{{ htpasswd }}@{{ (ansible_ssh_host | \
           default(ansible_host)) | default(inventory_hostname) }}/autobrr/"
@@ -68,26 +107,16 @@
   tags:
     - smoke_tests
 
-- name: TEST | 8.7 Debug
+- name: TEST | 8.13 Show the smoke test results
   ansible.builtin.debug:
     msg:
       - "Results:"
-      - "SSH: {{ test_ssh.state }}"
-      - "FTP: {{ test_ftp.state }}"
-      - "RTORRENT: {{ test_rtorrent.state }}"
-      - "RTORRENT HTTPRPC: {{ test_rpc.status }}"
-      - "RUTORRENT: {{ test_https.status }}"
-      - "AUTOBRR: {{ test_autobrr.status }}"
-  tags:
-    - smoke_tests
-
-- name: TEST | 8.8 Populate service facts
-  ansible.builtin.service_facts:
-  tags:
-    - smoke_tests
-
-- name: TEST | 8.9 Print service facts
-  ansible.builtin.debug:
-    var: ansible_facts.services
+      - "########"
+      - "SSH:               {{ test_ssh.state }}"
+      - "FTP:               {{ test_ftp.state }}"
+      - "RTORRENT:          {{ test_rtorrent.state }}"
+      - "RTORRENT HTTPRPC:  {{ test_rpc.msg }}"
+      - "RUTORRENT:         {{ test_https.msg }}"
+      - "AUTOBRR:           {{ test_autobrr.msg }}"
   tags:
     - smoke_tests

--- a/templates/autobrr/upgrade_autobrr.sh.j2
+++ b/templates/autobrr/upgrade_autobrr.sh.j2
@@ -1,15 +1,19 @@
 #!/bin/bash
 # {{ ansible_managed }}
 
+##############################################
 export AUTOBRR_VERSION="{{ autobrr_version }}"
-
+##############################################
 wget https://github.com/autobrr/autobrr/releases/download/v${AUTOBRR_VERSION}/autobrr_${AUTOBRR_VERSION}_linux_x86_64.tar.gz
 tar xvzf autobrr_${AUTOBRR_VERSION}_linux_x86_64.tar.gz
 sudo systemctl stop autobrr@{{ ansible_user }}.service
 sudo mv -v autobrr autobrrctl /usr/local/bin/
 sudo restorecon -Rv /usr/local/bin/
-tar cvzf autobrr_backup_$(date +%Y-%m-%d_%H%M%S).tgz ~/.config/autobrr
+export AUTOBRR_CURRENT_VERSION=$(autobrrctl version | grep 'Version: ' | cut -d ' ' -f 2)
+echo "${AUTOBRR_CURRENT_VERSION}" > /home/{{ ansible_user }}/.config/autobrr/.current_version
+tar cvzf autobrr_backup_$(date +%Y-%m-%d_%H%M%S).tgz /home/{{ ansible_user }}/.config/autobrr
 sudo systemctl start autobrr@{{ ansible_user }}.service
 sudo systemctl is-active autobrr@{{ ansible_user }}.service
 rm -vf autobrr_${AUTOBRR_VERSION}_linux_x86_64.tar.gz LICENSE README.md
+mv -v autobrr_backup_$(date +%Y-%m-%d_%H%M%S).tgz /home/{{ ansible_user }}/site/UPLOAD/
 echo "Upgrade of autobrr to version ${AUTOBRR_VERSION} finished!"

--- a/templates/rtorrent/config.php.j2
+++ b/templates/rtorrent/config.php.j2
@@ -1,8 +1,9 @@
 <?php
-  # {{ ansible_managed }}
-  @define('HTTP_USER_AGENT', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36', true);
-  @define('HTTP_TIME_OUT', 30, true);
-  @define('HTTP_USE_GZIP', true, true);
+  // {{ ansible_managed }}
+
+  $httpUserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36';
+  $httpTimeOut = 30;
+  $httpUseGzip = true;
   $httpIP = null;
   $httpProxy = array
   (
@@ -11,13 +12,14 @@
     'host' => 'PROXY_HOST_HERE',
     'port' => 3128
   );
-  @define('RPC_TIME_OUT', 5, true);
-  @define('LOG_RPC_CALLS', false, true);
-  @define('LOG_RPC_FAULTS', true, true);
-  @define('PHP_USE_GZIP', false, false);
-  @define('PHP_GZIP_LEVEL', 2, true);
-  $schedule_rand = 10;
-  $do_diagnostic = true;
+  $rpcTimeOut = 5;
+  $rpcLogCalls = false;
+  $rpcLogFaults = true;
+  $phpUseGzip = false;
+  $phpGzipLevel = 2;
+  $schedule_rand = 5;
+  $do_diagnostic = false;
+  $al_diagnostic = false;
   $saveUploadedTorrents = true;
   $overwriteUploadedTorrents = false;
   $topDirectory = '/home/{{ ansible_user }}/site/';
@@ -25,6 +27,7 @@
   $scgi_port = 0;
   $scgi_host = "unix:///home/{{ ansible_user }}/.Session/rpc.socket";
   $XMLRPCMountPoint = "/RPC2";
+  $throttleMaxSpeed = 327625*1024;
   $pathToExternals = array(
     "php" => '',
     "curl" => '',
@@ -33,6 +36,9 @@
     "stat" => '',
     "python" => '',
   );
+  $localHostedMode = true;
+  $cachedPluginLoading = false;
+  $pluginMinification = true;
   $localhosts = array(
     "127.0.0.1",
     "localhost",

--- a/templates/rtorrent/config.php.j2
+++ b/templates/rtorrent/config.php.j2
@@ -23,7 +23,7 @@
   $saveUploadedTorrents = false;
   $overwriteUploadedTorrents = false;
   $topDirectory = '/home/{{ ansible_user }}/site/';
-  $forbidUserSettings = true;
+  $forbidUserSettings = false;
   $scgi_port = 0;
   $scgi_host = "unix:///home/{{ ansible_user }}/.Session/rpc.socket";
   $XMLRPCMountPoint = "/RPC2";

--- a/templates/rtorrent/config.php.j2
+++ b/templates/rtorrent/config.php.j2
@@ -14,13 +14,13 @@
   );
   $rpcTimeOut = 5;
   $rpcLogCalls = false;
-  $rpcLogFaults = true;
+  $rpcLogFaults = false;
   $phpUseGzip = false;
   $phpGzipLevel = 2;
   $schedule_rand = 5;
   $do_diagnostic = false;
   $al_diagnostic = false;
-  $saveUploadedTorrents = true;
+  $saveUploadedTorrents = false;
   $overwriteUploadedTorrents = false;
   $topDirectory = '/home/{{ ansible_user }}/site/';
   $forbidUserSettings = true;

--- a/templates/rtorrent/rtorrent.rc.j2
+++ b/templates/rtorrent/rtorrent.rc.j2
@@ -48,14 +48,14 @@ protocol.encryption.set = allow_incoming,try_outgoing,enable_retry
 ## Limits for file handle resources, this is optimized for
 ## an `ulimit` of 1024 (a common default). You MUST leave
 ## a ceiling of handles reserved for rTorrent's internal needs!
-network.http.max_open.set = 99
-network.max_open_files.set = 600
-network.max_open_sockets.set = 999
+network.http.max_open.set = {{ maximum_number_of_open_file_descriptors }}
+network.max_open_files.set = {{ maximum_number_of_open_file_descriptors }}
+network.max_open_sockets.set = {{ maximum_number_of_open_file_descriptors }}
 
 ## Memory resource usage (increase if you have a large number of items loaded,
 ## and/or the available resources to spend)
 pieces.memory.max.set = {{ rt_memory_max_set }}
-network.xmlrpc.size_limit.set = 2M
+network.xmlrpc.size_limit.set = 4M
 # Preloading a piece of a file. Default: `0` Possible values: `0` (Off) , `1` (Madvise) , `2` (Direct paging).
 pieces.preload.type.set = 2
 
@@ -104,7 +104,7 @@ schedule2 = watch_directory_9,7,7,"load.start=~/site/.WatchXXX/*.torrent,d.direc
 ratio.enable =
 ratio.max.set = 500
 ratio.min.set = 400
-ratio.upload.set = 100M
+ratio.upload.set = 50M
 method.set = group.seeding.ratio.command,d.close=
 
 ## Run the rTorrent process as a daemon in the background

--- a/templates/rtorrent/rtorrent.service.j2
+++ b/templates/rtorrent/rtorrent.service.j2
@@ -1,17 +1,18 @@
 # {{ ansible_managed }}
 [Unit]
-Description=rTorrent Service
-Requires=network.target local-fs.target
+Description=rTorrent Service (inside tmux)
+After=network.target local-fs.target
 
 [Service]
-ExecStartPre=/bin/bash -c "if test -e /home/{{ ansible_user }}/.Session/rtorrent.lock && test -z $(pidof rtorrent); then rm -f /home/{{ ansible_user }}/.Session/rtorrent.lock; fi"
-ExecStart=/usr/bin/tmux -2 new-session -s rt -n rtorrent -d /usr/local/bin/rtorrent
-ExecStop=/usr/bin/tmux send-keys -t rt:rtorrent C-q
-RemainAfterExit=yes
-Restart=on-failure
 Type=forking
 User={{ ansible_user }}
 WorkingDirectory=/home/{{ ansible_user }}
+ExecStartPre=/bin/bash -c "if [ -e /home/{{ ansible_user }}/.Session/rtorrent.lock ]; then rm -f /home/{{ ansible_user }}/.Session/rtorrent.lock; fi"
+ExecStart=/usr/bin/tmux new-session -s rt -d "/usr/local/bin/rtorrent"
+ExecStop=/usr/bin/tmux send-keys -t rt:rtorrent C-q ENTER
+ExecStopPost=/bin/bash -c "timeout 10 sh -c 'while pgrep -f rtorrent; do sleep 1; done'"
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/sshd/sshd_config.j2
+++ b/templates/sshd/sshd_config.j2
@@ -16,6 +16,7 @@ ChallengeResponseAuthentication no
 GSSAPIAuthentication yes
 GSSAPICleanupCredentials no
 UsePAM yes
+UseDNS no
 X11Forwarding yes
 PrintMotd no
 PrintLastLog no


### PR DESCRIPTION
## [2.2.0] - 2025-03-27

### Added

- UseDNS no to sshd
- AB current_version injection into a backup in the upgrade script
- `maximum_number_of_open_file_descriptors` in common tasks
- Discard unused blocks once a week
- Display service_facts in smoke tests
- new default variable
- New limited firewalld zone for SSHD access

### Changed

- systemd definition of rTorrent service inside tmux
- Standardized ruT config definitions to maintain a consistent...
- Bumped ab & sc versions, added maximum_number_of_open_file_d...
- Updated rtorrent.rc with maximum_number_of_open_file_descrip...
- Minor improvement with ruT plugins
- journald rotation improvement
- `fail2ban_ignore_ipv4` to include private ranges

### Removed

- logrotate completely

### Deprecated

- N/A

### Fixed

- Incorrect role name in a few places
- yamllint & ansible-lint passing

### Security

- `fail2ban_ignore_ipv4` IS NOW ALSO USED BY FIREWALLD!!!!!!!!!!